### PR TITLE
fix(manager): ensure valid `dataSourceInformation` entries before app…

### DIFF
--- a/components/manager/internal/services/get-data-source-information.go
+++ b/components/manager/internal/services/get-data-source-information.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"plugin-smart-templates/v2/pkg/model"
+	"strings"
 
 	"github.com/LerianStudio/lib-commons/v2/commons"
 	libOpentelemetry "github.com/LerianStudio/lib-commons/v2/commons/opentelemetry"
@@ -49,7 +50,9 @@ func (uc *UseCase) GetDataSourceInformation(ctx context.Context) []*model.DataSo
 			}
 		}
 
-		result = append(result, dataSourceInformation)
+		if dataSourceInformation != nil && strings.TrimSpace(dataSourceInformation.Id) != "" {
+			result = append(result, dataSourceInformation)
+		}
 	}
 
 	return result

--- a/components/manager/internal/services/get-data-source-information_test.go
+++ b/components/manager/internal/services/get-data-source-information_test.go
@@ -102,7 +102,7 @@ func Test_GetDataSourceInformation(t *testing.T) {
 			expectResult: []*model.DataSourceInformation{},
 		},
 		{
-			name: "Unknown type - should return nil entry",
+			name: "Unknown type - should return empty slice",
 			setupSvc: func() *UseCase {
 				return &UseCase{
 					ExternalDataSources: map[string]pkg.DataSource{
@@ -112,7 +112,7 @@ func Test_GetDataSourceInformation(t *testing.T) {
 					},
 				}
 			},
-			expectResult: []*model.DataSourceInformation{nil},
+			expectResult: []*model.DataSourceInformation{},
 		},
 	}
 
@@ -121,11 +121,6 @@ func Test_GetDataSourceInformation(t *testing.T) {
 			svc := tt.setupSvc()
 			result := svc.GetDataSourceInformation(ctx)
 			assert.ElementsMatch(t, tt.expectResult, result)
-
-			if len(tt.expectResult) == 1 && tt.expectResult[0] == nil {
-				assert.Len(t, result, 1)
-				assert.Nil(t, result[0])
-			}
 		})
 	}
 }


### PR DESCRIPTION
…ending to results :bug:

# Pull Request Checklist

## Pull Request Type
[//]: # (Check the appropriate box for the type of pull request.)

- [x] Manager
- [ ] Worker
- [ ] Infrastructure
- [ ] Packages
- [ ] Pipeline
- [ ] Tests
- [ ] Documentation

## Checklist
Please check each item after it's completed.

- [x] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Additional Notes
[//]: # (Add any additional notes, context, or explanation that could be helpful for reviewers.)
## Obs: Please, always remember to target your PR to develop branch instead of main.

---

This pull request refines the `GetDataSourceInformation` service to ensure that only valid data source entries are included in the response.

Previously, the service could return `nil` entries or entries with an empty or whitespace-only `Id`. This change introduces a validation check that filters out `dataSourceInformation` objects if they are `nil` or if their `Id` field is effectively empty after trimming whitespace.

The associated test cases have been updated to reflect this new behavior, now expecting an empty slice instead of a slice containing a `nil` entry when an unknown data source type is encountered, aligning with the improved data integrity.