### PR TITLE
fix: Bump up limit of templates when creating report

### DIFF
--- a/components/frontend/src/app/(routes)/reports/reports-data-table.tsx
+++ b/components/frontend/src/app/(routes)/reports/reports-data-table.tsx
@@ -30,7 +30,7 @@ import { ReportDto } from '@/core/application/dto/report-dto'
 import { PaginationDto } from '@/core/application/dto/pagination-dto'
 import { IdTableCell } from '@/components/table/id-table-cell'
 import { useDownloadReport } from '@/client/reports'
-import { toast, useToast } from '@/hooks/use-toast'
+import { useToast } from '@/hooks/use-toast'
 import { useOrganization } from '@lerianstudio/console-layout'
 
 type ReportsDataTableProps = {

--- a/components/frontend/src/app/(routes)/reports/reports-sheet.tsx
+++ b/components/frontend/src/app/(routes)/reports/reports-sheet.tsx
@@ -71,7 +71,9 @@ export function ReportsSheet({
 
   // Fetch templates for dropdown
   const { data: templates } = useListTemplates({
-    organizationId: currentOrganization?.id || ''
+    organizationId: currentOrganization?.id!,
+    page: 1,
+    limit: 100
   })
 
   // Fetch data sources for database dropdown


### PR DESCRIPTION
# Pull Request Checklist

## Pull Request Type
[//]: # (Check the appropriate box for the type of pull request.)

- [ ] Manager
- [ ] Worker
- [ ] Infrastructure
- [ ] Packages
- [ ] Pipeline
- [ ] Tests
- [ ] Documentation

## Checklist
Please check each item after it's completed.

- [ ] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary comments to the code, especially in complex areas.
- [ ] I have ensured that my changes adhere to the project's coding standards.
- [ ] I have checked for any potential security issues.
- [ ] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [ ] I have confirmed this code is ready for review.

## Additional Notes
[//]: # (Add any additional notes, context, or explanation that could be helpful for reviewers.)
## Obs: Please, always remember to target your PR to develop branch instead of main.

---

Refactored the report creation sheet to increase the number of templates fetched for the dropdown selection. Previously, the template list might have been limited, but now it explicitly requests up to 100 templates, ensuring more options are available when creating a new report.

Additionally, an unused import of `toast` was removed from the reports data table component.