### PR TITLE
fix: Adding condition to release-candidate branch. :bug:

### DIFF
--- a/.github/workflows/check-branch.yml
+++ b/.github/workflows/check-branch.yml
@@ -33,7 +33,9 @@ jobs:
           git_commit_gpgsign: true
 
       - name: Check if PR is from develop or hotfix
-        if: github.event.pull_request.head.ref != 'develop' && startsWith(github.event.pull_request.head.ref, 'hotfix/') == false
+        if: github.event.pull_request.head.ref != 'develop' 
+          && github.event.pull_request.head.ref != 'release-candidate' 
+          &&  startsWith(github.event.pull_request.head.ref, 'hotfix/') == false
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GIT_AUTHOR_NAME: ${{ secrets.LERIAN_CI_CD_USER_NAME }}


### PR DESCRIPTION
# Pull Request Checklist

## Pull Request Type
[//]: # (Check the appropriate box for the type of pull request.)

- [ ] Manager
- [ ] Worker
- [ ] Frontend
- [ ] Infrastructure
- [ ] Packages
- [ ] Pipeline
- [ ] Tests
- [ ] Documentation

## Checklist
Please check each item after it's completed.

- [ ] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary comments to the code, especially in complex areas.
- [ ] I have ensured that my changes adhere to the project's coding standards.
- [ ] I have checked for any potential security issues.
- [ ] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [ ] I have confirmed this code is ready for review.

## Additional Notes
[//]: # (Add any additional notes, context, or explanation that could be helpful for reviewers.)
## Obs: Please, always remember to target your PR to develop branch instead of main.

---

<!-- kody-pr-summary:start -->
Updates the `check-branch.yml` GitHub Actions workflow to modify the condition for the "Check if PR is from develop or hotfix" step. This change adds an explicit exclusion for the `release-candidate` branch, preventing the check from running when a pull request originates from `release-candidate`.
<!-- kody-pr-summary:end -->