### PR TITLE
Fix: Download PDF to use temporary file approach

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,22 @@ sec:
 .PHONY: clean
 clean:
 	$(call title1,"Cleaning build artifacts")
-	@rm -rf $(BIN_DIR)/* $(ARTIFACTS_DIR)/*
+	@if [ -z "$(BIN_DIR)" ] || [ -z "$(ARTIFACTS_DIR)" ]; then \
+		echo "$(RED)$(BOLD)[error]$(NC) BIN_DIR or ARTIFACTS_DIR is not set. Aborting to prevent accidental deletion.$(RED) ❌$(NC)"; \
+		exit 1; \
+	fi
+	@if [ "$(BIN_DIR)" = "/" ] || [ "$(ARTIFACTS_DIR)" = "/" ]; then \
+		echo "$(RED)$(BOLD)[error]$(NC) BIN_DIR or ARTIFACTS_DIR cannot be root directory. Aborting.$(RED) ❌$(NC)"; \
+		exit 1; \
+	fi
+	@if [ -d "$(BIN_DIR)" ]; then \
+		echo "$(CYAN)Cleaning $(BIN_DIR)...$(NC)"; \
+		rm -rf $(BIN_DIR)/*; \
+	fi
+	@if [ -d "$(ARTIFACTS_DIR)" ]; then \
+		echo "$(CYAN)Cleaning $(ARTIFACTS_DIR)...$(NC)"; \
+		rm -rf $(ARTIFACTS_DIR)/*; \
+	fi
 	@echo "$(GREEN)$(BOLD)[ok]$(NC) Artifacts cleaned successfully$(GREEN) ✔️$(NC)"
 
 #-------------------------------------------------------

--- a/components/frontend/Makefile
+++ b/components/frontend/Makefile
@@ -188,8 +188,24 @@ i18n:
 
 clean:
 	$(call title1,"Cleaning build artifacts")
+	@if [ -z "$(BUILD_DIR)" ] || [ -z "$(ARTIFACTS_DIR)" ]; then \
+		echo "ERROR: BUILD_DIR or ARTIFACTS_DIR is not set. Aborting to prevent accidental deletion."; \
+		exit 1; \
+	fi
+	@if [ "$(BUILD_DIR)" = "/" ] || [ "$(ARTIFACTS_DIR)" = "/" ]; then \
+		echo "ERROR: BUILD_DIR or ARTIFACTS_DIR cannot be root directory. Aborting."; \
+		exit 1; \
+	fi
 	@echo "Cleaning $(SERVICE_NAME) artifacts..."
-	@rm -rf $(BUILD_DIR) $(ARTIFACTS_DIR) coverage coverage.out coverage.html *.tmp
+	@if [ -d "$(BUILD_DIR)" ]; then \
+		echo "Removing $(BUILD_DIR)..."; \
+		rm -rf $(BUILD_DIR); \
+	fi
+	@if [ -d "$(ARTIFACTS_DIR)" ]; then \
+		echo "Removing $(ARTIFACTS_DIR)..."; \
+		rm -rf $(ARTIFACTS_DIR); \
+	fi
+	@rm -f coverage coverage.out coverage.html *.tmp
 	@if [ -d "node_modules" ]; then \
 		echo "Removing node_modules..."; \
 		rm -rf node_modules; \
@@ -198,4 +214,4 @@ clean:
 		echo "Removing .next..."; \
 		rm -rf .next; \
 	fi
-	@echo "$(OK_COLOR)[ok] Artifacts cleaned successfully ✔️$(NO_COLOR)"
+	@echo "[ok] Artifacts cleaned successfully ✔️"

--- a/components/frontend/package-lock.json
+++ b/components/frontend/package-lock.json
@@ -61,7 +61,7 @@
         "lucide-react": "^0.536.0",
         "mongoose": "^8.16.0",
         "next": "^15.3.3",
-        "next-auth": "^4.24.11",
+        "next-auth": "^4.24.12",
         "path-to-regexp": "^8.2.0",
         "react": "^19.1.0",
         "react-day-picker": "^9.9.0",
@@ -18608,9 +18608,9 @@
       }
     },
     "node_modules/next-auth": {
-      "version": "4.24.11",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.11.tgz",
-      "integrity": "sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==",
+      "version": "4.24.13",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.13.tgz",
+      "integrity": "sha512-sgObCfcfL7BzIK76SS5TnQtc3yo2Oifp/yIpfv6fMfeBOiBJkDWF3A2y9+yqnmJ4JKc2C+nMjSjmgDeTwgN1rQ==",
       "license": "ISC",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
@@ -18624,9 +18624,9 @@
         "uuid": "^8.3.2"
       },
       "peerDependencies": {
-        "@auth/core": "0.34.2",
-        "next": "^12.2.5 || ^13 || ^14 || ^15",
-        "nodemailer": "^6.6.5",
+        "@auth/core": "0.34.3",
+        "next": "^12.2.5 || ^13 || ^14 || ^15 || ^16",
+        "nodemailer": "^7.0.7",
         "react": "^17.0.2 || ^18 || ^19",
         "react-dom": "^17.0.2 || ^18 || ^19"
       },

--- a/components/frontend/package.json
+++ b/components/frontend/package.json
@@ -82,7 +82,7 @@
     "lucide-react": "^0.536.0",
     "mongoose": "^8.16.0",
     "next": "^15.3.3",
-    "next-auth": "^4.24.11",
+    "next-auth": "^4.24.12",
     "path-to-regexp": "^8.2.0",
     "react": "^19.1.0",
     "react-day-picker": "^9.9.0",

--- a/pkg/pdf/pool.go
+++ b/pkg/pdf/pool.go
@@ -53,7 +53,15 @@ func NewWorkerPool(num int, timeout time.Duration, logger log.Logger) *WorkerPoo
 func (wp *WorkerPool) startWorker(_ int) {
 	defer wp.wg.Done()
 
-	// Optimized Chrome configuration for container environment
+	ctx := wp.initializeChromeContext()
+
+	for task := range wp.tasks {
+		wp.processTask(ctx, task)
+	}
+}
+
+// initializeChromeContext initializes a Chrome context with optimized flags for container environments.
+func (wp *WorkerPool) initializeChromeContext() context.Context {
 	opts := append(chromedp.DefaultExecAllocatorOptions[:],
 		chromedp.Flag("headless", true),
 		chromedp.Flag("no-sandbox", true),
@@ -68,121 +76,143 @@ func (wp *WorkerPool) startWorker(_ int) {
 		chromedp.Flag("memory-pressure-off", true),
 	)
 
-	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(), opts...)
-	defer cancel()
+	allocCtx, _ := chromedp.NewExecAllocator(context.Background(), opts...)
+	ctx, _ := chromedp.NewContext(allocCtx)
 
-	ctx, cancel := chromedp.NewContext(allocCtx)
-	defer cancel()
+	return ctx
+}
 
-	for task := range wp.tasks {
-		ctxTimeout, cancelTimeout := context.WithTimeout(ctx, wp.timeout)
+// processTask handles a single PDF generation task.
+func (wp *WorkerPool) processTask(ctx context.Context, task Task) {
+	ctxTimeout, cancelTimeout := context.WithTimeout(ctx, wp.timeout)
+	defer cancelTimeout()
 
-		var pdfBuf []byte
+	wp.logger.Infof("Starting PDF generation for task: %s (HTML size: %d bytes)", task.Filename, len(task.HTML))
 
-		wp.logger.Infof("Starting PDF generation for task: %s (HTML size: %d bytes)", task.Filename, len(task.HTML))
-
-		// Use temporary file approach (more reliable than data URL in containers)
-		tmpFile, tmpErr := os.CreateTemp("", "pdf-*.html")
-		if tmpErr != nil {
-			err := fmt.Errorf("failed to create temp HTML file: %v", tmpErr)
-			wp.logger.Errorf("PDF generation failed: %v", err)
-			cancelTimeout()
-
-			task.Result <- err
-
-			continue
-		}
-
-		tmpFileName := tmpFile.Name()
-		if closeErr := tmpFile.Close(); closeErr != nil {
-			wp.logger.Warnf("Failed to close temp file %s: %v", tmpFileName, closeErr)
-		}
-
-		// Write HTML to temp file
-		if writeErr := os.WriteFile(tmpFileName, []byte(task.HTML), 0600); writeErr != nil {
-			err := fmt.Errorf("failed to write HTML to temp file: %v", writeErr)
-			wp.logger.Errorf("PDF generation failed: %v", err)
-
-			if removeErr := os.Remove(tmpFileName); removeErr != nil {
-				wp.logger.Warnf("Failed to remove temp file %s: %v", tmpFileName, removeErr)
-			}
-
-			cancelTimeout()
-
-			task.Result <- err
-
-			continue
-		}
-
-		// Generate PDF from file
-		fileURL := "file://" + filepath.ToSlash(tmpFileName)
-		wp.logger.Infof("Navigating to file URL: %s", fileURL)
-
-		err := chromedp.Run(ctxTimeout,
-			chromedp.Navigate(fileURL),
-			chromedp.WaitVisible("body", chromedp.ByQuery),
-			chromedp.ActionFunc(func(ctx context.Context) error {
-				return network.Enable().Do(ctx)
-			}),
-			chromedp.WaitReady("body", chromedp.ByQuery),
-			chromedp.Sleep(500*time.Millisecond),
-			chromedp.ActionFunc(func(ctx context.Context) error {
-				var err error
-
-				pdfBuf, _, err = page.PrintToPDF().
-					WithPrintBackground(true).
-					WithPaperWidth(8.5).
-					WithPaperHeight(11).
-					WithMarginTop(0.5).
-					WithMarginBottom(0.5).
-					WithMarginLeft(0.5).
-					WithMarginRight(0.5).
-					WithDisplayHeaderFooter(false).
-					Do(ctx)
-
-				return err
-			}),
-		)
-
-		// Process PDF generation result
-		if err == nil {
-			if len(pdfBuf) < 1000 {
-				err = fmt.Errorf("generated PDF is too small (%d bytes), likely empty", len(pdfBuf))
-				wp.logger.Errorf("Final PDF too small: %d bytes", len(pdfBuf))
-			} else {
-				err = os.WriteFile(task.Filename, pdfBuf, 0600)
-				if err != nil {
-					wp.logger.Errorf("Failed to write PDF file: %v", err)
-				} else {
-					wp.logger.Infof("PDF generated successfully: %d bytes written to %s", len(pdfBuf), task.Filename)
-				}
-			}
-		} else {
-			if errors.Is(ctxTimeout.Err(), context.DeadlineExceeded) {
-				wp.logger.Errorf("PDF generation timeout (configured timeout: %v): %v", wp.timeout, err)
-			} else if errors.Is(ctxTimeout.Err(), context.Canceled) {
-				wp.logger.Errorf("PDF generation context canceled: %v", err)
-			} else {
-				wp.logger.Errorf("PDF generation failed: %v", err)
-			}
-		}
-
-		// Clean up temporary HTML file - critical operation
-		// Failure to remove temp files will cause disk space exhaustion in long-running services
-		if removeErr := os.Remove(tmpFileName); removeErr != nil {
-			wp.logger.Errorf("Failed to remove temp file %s: %v", tmpFileName, removeErr)
-			if err == nil {
-				// PDF generation succeeded but cleanup failed - this is still an error
-				err = fmt.Errorf("generated PDF successfully but failed to remove temp file %s: %w", tmpFileName, removeErr)
-			} else {
-				// Both PDF generation and cleanup failed - wrap both errors
-				err = fmt.Errorf("%w; additionally failed to remove temp file %s: %v", err, tmpFileName, removeErr)
-			}
-		}
-
-		cancelTimeout()
-
+	tmpFileName, err := wp.createTempHTMLFile(task.HTML)
+	if err != nil {
 		task.Result <- err
+		return
+	}
+
+	pdfBuf, err := wp.generatePDFFromFile(ctxTimeout, tmpFileName)
+
+	err = wp.processPDFResult(pdfBuf, task.Filename, err)
+
+	err = wp.cleanupTempFile(tmpFileName, err)
+
+	task.Result <- err
+}
+
+// createTempHTMLFile creates a temporary HTML file with the provided content.
+func (wp *WorkerPool) createTempHTMLFile(html string) (string, error) {
+	tmpFile, err := os.CreateTemp("", "pdf-*.html")
+	if err != nil {
+		wp.logger.Errorf("Failed to create temp HTML file: %v", err)
+		return "", fmt.Errorf("failed to create temp HTML file: %w", err)
+	}
+
+	tmpFileName := tmpFile.Name()
+
+	if err := tmpFile.Close(); err != nil {
+		wp.logger.Warnf("Failed to close temp file %s: %v", tmpFileName, err)
+	}
+
+	if err := os.WriteFile(tmpFileName, []byte(html), 0600); err != nil {
+		wp.logger.Errorf("Failed to write HTML to temp file: %v", err)
+
+		_ = os.Remove(tmpFileName)
+
+		return "", fmt.Errorf("failed to write HTML to temp file: %w", err)
+	}
+
+	return tmpFileName, nil
+}
+
+// generatePDFFromFile generates a PDF from an HTML file using Chrome.
+func (wp *WorkerPool) generatePDFFromFile(ctx context.Context, htmlFilePath string) ([]byte, error) {
+	fileURL := "file://" + filepath.ToSlash(htmlFilePath)
+	wp.logger.Infof("Navigating to file URL: %s", fileURL)
+
+	var pdfBuf []byte
+
+	err := chromedp.Run(ctx,
+		chromedp.Navigate(fileURL),
+		chromedp.WaitVisible("body", chromedp.ByQuery),
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			return network.Enable().Do(ctx)
+		}),
+		chromedp.WaitReady("body", chromedp.ByQuery),
+		chromedp.Sleep(500*time.Millisecond),
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			var err error
+
+			pdfBuf, _, err = page.PrintToPDF().
+				WithPrintBackground(true).
+				WithPaperWidth(8.5).
+				WithPaperHeight(11).
+				WithMarginTop(0.5).
+				WithMarginBottom(0.5).
+				WithMarginLeft(0.5).
+				WithMarginRight(0.5).
+				WithDisplayHeaderFooter(false).
+				Do(ctx)
+
+			return err
+		}),
+	)
+	if err != nil {
+		wp.logPDFGenerationError(ctx, err)
+		return nil, err
+	}
+
+	return pdfBuf, nil
+}
+
+// processPDFResult validates and writes the generated PDF to disk.
+func (wp *WorkerPool) processPDFResult(pdfBuf []byte, filename string, err error) error {
+	if err != nil {
+		return err
+	}
+
+	if len(pdfBuf) < 1000 {
+		wp.logger.Errorf("Final PDF too small: %d bytes", len(pdfBuf))
+		return fmt.Errorf("generated PDF is too small (%d bytes), likely empty", len(pdfBuf))
+	}
+
+	if err := os.WriteFile(filename, pdfBuf, 0600); err != nil {
+		wp.logger.Errorf("Failed to write PDF file: %v", err)
+		return err
+	}
+
+	wp.logger.Infof("PDF generated successfully: %d bytes written to %s", len(pdfBuf), filename)
+
+	return nil
+}
+
+// cleanupTempFile removes the temporary HTML file and wraps cleanup errors with the original error.
+func (wp *WorkerPool) cleanupTempFile(tmpFileName string, originalErr error) error {
+	if err := os.Remove(tmpFileName); err != nil {
+		wp.logger.Errorf("Failed to remove temp file %s: %v", tmpFileName, err)
+
+		if originalErr == nil {
+			return fmt.Errorf("generated PDF successfully but failed to remove temp file %s: %w", tmpFileName, err)
+		}
+
+		return fmt.Errorf("%w; additionally failed to remove temp file %s: %v", originalErr, tmpFileName, err)
+	}
+
+	return originalErr
+}
+
+// logPDFGenerationError logs PDF generation errors with appropriate context.
+func (wp *WorkerPool) logPDFGenerationError(ctx context.Context, err error) {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		wp.logger.Errorf("PDF generation timeout (configured timeout: %v): %v", wp.timeout, err)
+	} else if errors.Is(ctx.Err(), context.Canceled) {
+		wp.logger.Errorf("PDF generation context canceled: %v", err)
+	} else {
+		wp.logger.Errorf("PDF generation failed: %v", err)
 	}
 }
 


### PR DESCRIPTION
# Pull Request Checklist

## Pull Request Type
[//]: # (Check the appropriate box for the type of pull request.)

- [x] Manager
- [ ] Worker
- [ ] Frontend
- [ ] Infrastructure
- [ ] Packages
- [ ] Pipeline
- [ ] Tests
- [ ] Documentation

## Checklist
Please check each item after it's completed.

- [x] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [ ] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Additional Notes
[//]: # (Add any additional notes, context, or explanation that could be helpful for reviewers.)
## Obs: Please, always remember to target your PR to develop branch instead of main.

---

<!-- kody-pr-summary:start -->
This pull request updates the PDF generation process to exclusively use a temporary file approach instead of `data:text/html` URLs.

Key changes include:
*   **Primary PDF Generation Method:** The system now consistently writes the HTML content to a temporary file on disk. `chromedp` then navigates to this local file using a `file://` URL to generate the PDF.
*   **Removed Fallback Logic:** The previous mechanism, which attempted to generate a PDF using a `data:text/html` URL first and only fell back to a temporary file if the result was too small, has been removed. The temporary file method is now the default and only approach.
*   **Enhanced Error Handling and Logging:** Improved error handling for temporary file operations (creation, writing, and removal) and more detailed logging for PDF generation status, including specific messages for timeouts and context cancellations.

This change aims to improve the reliability of PDF generation, especially in containerized environments where `data:text/html` URLs can sometimes be problematic.
<!-- kody-pr-summary:end -->