### PR TITLE
fix: handle binary file downloads correctly for PDF reports

### DIFF
--- a/components/frontend/src/core/application/controllers/report-controller.ts
+++ b/components/frontend/src/core/application/controllers/report-controller.ts
@@ -103,7 +103,18 @@ export class ReportController {
         organizationId
       })
 
-      return new NextResponse(downloadInfo.content, {
+      // Convert content to appropriate format for NextResponse
+      let responseBody: BodyInit
+
+      if (downloadInfo.content instanceof ArrayBuffer) {
+        // For binary data, use the ArrayBuffer directly
+        responseBody = downloadInfo.content
+      } else {
+        // For text data, use the string directly
+        responseBody = downloadInfo.content
+      }
+
+      return new NextResponse(responseBody, {
         status: 200,
         headers: {
           'Content-Type': downloadInfo.contentType,

--- a/components/frontend/src/core/application/use-cases/reports/download-report-use-case.ts
+++ b/components/frontend/src/core/application/use-cases/reports/download-report-use-case.ts
@@ -8,7 +8,7 @@ export type DownloadReportParams = {
 }
 
 export type DownloadReportResponse = {
-  content: string
+  content: string | ArrayBuffer
   fileName: string
   contentType: string
 }
@@ -26,7 +26,6 @@ export class DownloadReportUseCase implements DownloadReport {
 
   @LogOperation({ layer: 'application' })
   async execute(params: DownloadReportParams): Promise<DownloadReportResponse> {
-    // Get file content directly from the repository
     const downloadInfo = await this.reportRepository.downloadFile(
       params.id,
       params.organizationId

--- a/components/frontend/src/core/domain/repositories/report-repository.ts
+++ b/components/frontend/src/core/domain/repositories/report-repository.ts
@@ -10,8 +10,8 @@ import { PaginationEntity } from '../entities/pagination-entity'
  * File download response containing file content and metadata
  */
 export type DownloadFileResponse = {
-  /** File content as text */
-  content: string
+  /** File content as text or binary data */
+  content: string | ArrayBuffer
   /** Original filename */
   fileName: string
   /** MIME type of the file */

--- a/components/frontend/src/core/infrastructure/reporter/repositories/reporter-report-repository.ts
+++ b/components/frontend/src/core/infrastructure/reporter/repositories/reporter-report-repository.ts
@@ -121,16 +121,35 @@ export class ReporterReportRepository implements ReportRepository {
       organizationId
     )
 
-    const content = await this.httpService.getText(
-      `${this.baseUrl}/${id}/download`,
-      {
-        headers: {
-          'X-Organization-Id': organizationId
-        }
-      }
-    )
-
     const outputFormat = template.outputFormat || 'txt'
+
+    // Determine if the format is binary or text
+    // Only PDF is binary among the supported formats
+    const isBinary = outputFormat.toLowerCase() === 'pdf'
+
+    let content: string | ArrayBuffer
+
+    if (isBinary) {
+      // Use getBinary for PDF to preserve binary data integrity
+      content = await this.httpService.getBinary(
+        `${this.baseUrl}/${id}/download`,
+        {
+          headers: {
+            'X-Organization-Id': organizationId
+          }
+        }
+      )
+    } else {
+      // Use getText for text-based formats (HTML, XML, CSV, TXT)
+      content = await this.httpService.getText(
+        `${this.baseUrl}/${id}/download`,
+        {
+          headers: {
+            'X-Organization-Id': organizationId
+          }
+        }
+      )
+    }
 
     const contentTypeMap: Record<string, string> = {
       pdf: 'application/pdf',
@@ -140,7 +159,7 @@ export class ReporterReportRepository implements ReportRepository {
       txt: 'text/plain'
     }
 
-    const contentType = contentTypeMap[outputFormat] || 'text/plain'
+    const contentType = contentTypeMap[outputFormat.toLowerCase()] || 'text/plain'
 
     const sanitizedName = template.name.toLowerCase().replace(/\s+/g, '_')
     const fileName = `${sanitizedName}_${new Date().toISOString().split('T')[0]}.${outputFormat}`

--- a/components/frontend/src/core/infrastructure/reporter/repositories/reporter-report-repository.ts
+++ b/components/frontend/src/core/infrastructure/reporter/repositories/reporter-report-repository.ts
@@ -159,7 +159,8 @@ export class ReporterReportRepository implements ReportRepository {
       txt: 'text/plain'
     }
 
-    const contentType = contentTypeMap[outputFormat.toLowerCase()] || 'text/plain'
+    const contentType =
+      contentTypeMap[outputFormat.toLowerCase()] || 'text/plain'
 
     const sanitizedName = template.name.toLowerCase().replace(/\s+/g, '_')
     const fileName = `${sanitizedName}_${new Date().toISOString().split('T')[0]}.${outputFormat}`

--- a/components/frontend/src/core/infrastructure/reporter/services/reporter-http-service.ts
+++ b/components/frontend/src/core/infrastructure/reporter/services/reporter-http-service.ts
@@ -211,7 +211,10 @@ export class ReporterHttpService extends HttpService {
    * Handle binary responses for file content downloads
    * Returns the response content as ArrayBuffer for binary data
    */
-  async getBinary(url: URL | string, options: RequestInit = {}): Promise<ArrayBuffer> {
+  async getBinary(
+    url: URL | string,
+    options: RequestInit = {}
+  ): Promise<ArrayBuffer> {
     const defaults = await this.createDefaults()
 
     const request = new Request(new URL(url, defaults.baseUrl), {

--- a/components/frontend/src/core/infrastructure/reporter/services/reporter-http-service.ts
+++ b/components/frontend/src/core/infrastructure/reporter/services/reporter-http-service.ts
@@ -206,4 +206,37 @@ export class ReporterHttpService extends HttpService {
 
     return await response.text()
   }
+
+  /**
+   * Handle binary responses for file content downloads
+   * Returns the response content as ArrayBuffer for binary data
+   */
+  async getBinary(url: URL | string, options: RequestInit = {}): Promise<ArrayBuffer> {
+    const defaults = await this.createDefaults()
+
+    const request = new Request(new URL(url, defaults.baseUrl), {
+      ...defaults,
+      ...options,
+      method: 'GET',
+      headers: {
+        ...defaults.headers,
+        ...options.headers
+      }
+    })
+
+    this.onBeforeFetch(request)
+
+    const response = await fetch(request)
+
+    this.onAfterFetch(request, response)
+
+    if (!response.ok) {
+      const error = await response
+        .json()
+        .catch(() => ({ message: 'Download failed' }))
+      await this.catch(request, response, error)
+    }
+
+    return await response.arrayBuffer()
+  }
 }


### PR DESCRIPTION
- Add getBinary method to handle binary response data as ArrayBuffer
- Update downloadFile to use getBinary for PDF format
- Modify download response types to support both text and binary content
- Ensure proper Content-Type handling for all output formats
- Fix report controller to properly handle binary response bodies

This fix ensures PDF files are downloaded correctly without corruption while maintaining text-based format handling (HTML, XML, CSV, TXT).

# Pull Request Checklist

## Pull Request Type
[//]: # (Check the appropriate box for the type of pull request.)

- [ ] Manager
- [ ] Worker
- [x] Frontend
- [ ] Infrastructure
- [ ] Packages
- [ ] Pipeline
- [ ] Tests
- [ ] Documentation

## Checklist
Please check each item after it's completed.

- [x] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary comments to the code, especially in complex areas.
- [ ] I have ensured that my changes adhere to the project's coding standards.
- [ ] I have checked for any potential security issues.
- [ ] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [ ] I have confirmed this code is ready for review.

## Additional Notes
[//]: # (Add any additional notes, context, or explanation that could be helpful for reviewers.)
## Obs: Please, always remember to target your PR to develop branch instead of main.

---

<!-- kody-pr-summary:start -->
This pull request addresses an issue where binary files, specifically PDF reports, were not being downloaded correctly, leading to corrupted files.

The changes implement a robust mechanism to handle binary file downloads by:

*   **Introducing a `getBinary` method in the `ReporterHttpService`**: This new method allows fetching HTTP responses as an `ArrayBuffer`, preserving the integrity of binary data.
*   **Conditionally fetching report content in `ReporterReportRepository`**: The repository now checks the report's `outputFormat`. If the format is PDF, it utilizes the new `getBinary` method to fetch the content. For other text-based formats (HTML, XML, CSV, TXT), it continues to use the existing `getText` method.
*   **Updating data types to support binary content**: The `DownloadFileResponse` in the domain layer and `DownloadReportResponse` in the application layer now allow the `content` property to be either a `string` or an `ArrayBuffer`.
*   **Handling `ArrayBuffer` content in `ReportController`**: The controller now checks if the downloaded content is an `ArrayBuffer` and passes it directly to `NextResponse`, ensuring that binary data is streamed correctly to the client without corruption.

These modifications ensure that PDF reports and other potential binary files are downloaded and served accurately, resolving the corruption issue.
<!-- kody-pr-summary:end -->